### PR TITLE
feature: add ping for kafka

### DIFF
--- a/kafkajobs/config.go
+++ b/kafkajobs/config.go
@@ -13,6 +13,8 @@ import (
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 )
 
+const defaultPingTimeout = time.Duration(time.Second * 10)
+
 func (c *config) InitDefault() ([]kgo.Opt, error) {
 	opts := make([]kgo.Opt, 0, 1)
 
@@ -225,6 +227,12 @@ func (c *config) InitDefault() ([]kgo.Opt, error) {
 
 				kgo.ConsumePartitions(partitions)
 			}
+		}
+	}
+
+	if c.Ping == nil {
+		c.Ping = &Ping{
+			Timeout: defaultPingTimeout,
 		}
 	}
 

--- a/kafkajobs/config.go
+++ b/kafkajobs/config.go
@@ -13,7 +13,7 @@ import (
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 )
 
-const defaultPingTimeout = time.Duration(time.Second * 10)
+const defaultPingTimeout = time.Second * 10
 
 func (c *config) InitDefault() ([]kgo.Opt, error) {
 	opts := make([]kgo.Opt, 0, 1)

--- a/kafkajobs/driver.go
+++ b/kafkajobs/driver.go
@@ -115,7 +115,7 @@ func FromConfig(tracer *sdktrace.TracerProvider, configKey string, log *zap.Logg
 		return nil, errors.E(op, err)
 	}
 
-	err = pingKafka(jb.kafkaClient, log, conf.Ping.Timeout, pipeline)
+	err = ping(jb.kafkaClient, log, conf.Ping.Timeout, pipeline)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +221,7 @@ func FromPipeline(tracer *sdktrace.TracerProvider, pipeline jobs.Pipeline, log *
 		return nil, errors.E(op, err)
 	}
 
-	err = pingKafka(jb.kafkaClient, log, conf.Ping.Timeout, pipeline)
+	err = ping(jb.kafkaClient, log, conf.Ping.Timeout, pipeline)
 	if err != nil {
 		return nil, err
 	}
@@ -492,8 +492,8 @@ func (d *Driver) requeueHandler() {
 	}
 }
 
-func pingKafka(client *kgo.Client, log *zap.Logger, timeout time.Duration, pipe jobs.Pipeline) error {
-	const op = errors.Op("new_kafka_consumer")
+func ping(client *kgo.Client, log *zap.Logger, timeout time.Duration, pipe jobs.Pipeline) error {
+	const op = errors.Op("kafka_ping")
 
 	pingCtx, pingCancel := context.WithTimeout(context.Background(), timeout)
 	defer pingCancel()

--- a/kafkajobs/driver.go
+++ b/kafkajobs/driver.go
@@ -115,17 +115,15 @@ func FromConfig(tracer *sdktrace.TracerProvider, configKey string, log *zap.Logg
 		return nil, errors.E(op, err)
 	}
 
-	if conf.Ping != nil {
-		pingCtx, pingCancel := context.WithTimeout(context.Background(), conf.Ping.Timeout)
-		defer pingCancel()
+	pingCtx, pingCancel := context.WithTimeout(context.Background(), conf.Ping.Timeout)
+	defer pingCancel()
 
-		err := jb.kafkaClient.Ping(pingCtx)
-		if err != nil {
-			return nil, errors.E(op, errors.Errorf("ping kafka was failed: %s", err))
-		}
-
-		log.Debug("ping kafka: ok", zap.String("driver", pipeline.Driver()), zap.String("pipeline", pipeline.Name()))
+	err = jb.kafkaClient.Ping(pingCtx)
+	if err != nil {
+		return nil, errors.E(op, errors.Errorf("ping kafka was failed: %s", err))
 	}
+
+	log.Debug("ping kafka: ok", zap.String("driver", pipeline.Driver()), zap.String("pipeline", pipeline.Name()))
 
 	jb.pipeline.Store(&pipeline)
 
@@ -228,17 +226,15 @@ func FromPipeline(tracer *sdktrace.TracerProvider, pipeline jobs.Pipeline, log *
 		return nil, errors.E(op, err)
 	}
 
-	if conf.Ping != nil {
-		pingCtx, pingCancel := context.WithTimeout(context.Background(), conf.Ping.Timeout)
-		defer pingCancel()
+	pingCtx, pingCancel := context.WithTimeout(context.Background(), conf.Ping.Timeout)
+	defer pingCancel()
 
-		err := jb.kafkaClient.Ping(pingCtx)
-		if err != nil {
-			return nil, errors.E(op, errors.Errorf("ping kafka was failed: %s", err))
-		}
-
-		log.Debug("ping kafka: ok", zap.String("driver", pipeline.Driver()), zap.String("pipeline", pipeline.Name()))
+	err = jb.kafkaClient.Ping(pingCtx)
+	if err != nil {
+		return nil, errors.E(op, errors.Errorf("ping kafka was failed: %s", err))
 	}
+
+	log.Debug("ping kafka: ok", zap.String("driver", pipeline.Driver()), zap.String("pipeline", pipeline.Name()))
 
 	jb.pipeline.Store(&pipeline)
 

--- a/kafkajobs/driver.go
+++ b/kafkajobs/driver.go
@@ -236,6 +236,18 @@ func (d *Driver) Run(ctx context.Context, p jobs.Pipeline) error {
 		return errors.E(op, errors.Errorf("no such pipeline registered: %s", pipe.Name()))
 	}
 
+	if d.cfg.Ping != nil {
+		pingCtx, pingCancel := context.WithTimeout(ctx, d.cfg.Ping.Timeout)
+		defer pingCancel()
+
+		err := d.kafkaClient.Ping(pingCtx)
+		if err != nil {
+			return errors.E(op, errors.Errorf("ping kafka was failed: %s", err))
+		}
+
+		d.log.Debug("ping kafka: ok", zap.String("driver", pipe.Driver()), zap.String("pipeline", pipe.Name()))
+	}
+
 	d.mu.Lock()
 	defer d.mu.Unlock()
 

--- a/kafkajobs/opts.go
+++ b/kafkajobs/opts.go
@@ -65,6 +65,7 @@ type config struct {
 	// global
 	Brokers []string `mapstructure:"brokers"`
 	SASL    *SASL    `mapstructure:"sasl"`
+	Ping    *Ping    `mapstructure:"ping"`
 
 	// pipeline
 	Priority         int           `mapstructure:"priority"`
@@ -89,6 +90,10 @@ type SASL struct {
 	SecretKey    string `mapstructure:"secret_key" json:"secret_key"`
 	SessionToken string `mapstructure:"session_token" json:"session_token"`
 	UserAgent    string `mapstructure:"user_agent" json:"user_agent"`
+}
+
+type Ping struct {
+	Timeout time.Duration `mapstructure:"timeout" json:"timeout"`
 }
 
 type GroupOptions struct {


### PR DESCRIPTION
# Reason for This PR

At the moment, the pipeline starts even with a non-working connection to kafka. For example, I can specify the wrong broker and get no error. I would like to see an error if the connection to kafka is not working.

## Description of Changes

I've added a Ping{timeout} structure to the kafka configuration. I did it with a structure, because in the future it may be necessary to supplement the ping or do it more often. 

As a user i will get an error:

```
service-queue-1  | handle_serve_command: Function call error:
service-queue-1  |        serve error from the plugin *jobs.Plugin stopping execution, error: jobs_plugin_serve: kafka_run: ping kafka was failed: unable to dial: dial tcp 172.20.0.5:9093: connect: connection refused
```

This behavior will be optional to maintain backwards compatibility.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
