### PR TITLE
fix: returns full error when ping failed

### DIFF
--- a/kafkajobs/driver.go
+++ b/kafkajobs/driver.go
@@ -500,7 +500,7 @@ func (d *Driver) ping(client *kgo.Client, pipe jobs.Pipeline) error {
 
 	err := client.Ping(pingCtx)
 	if err != nil {
-		return errors.E(op, err, errors.Str("ping kafka was failed"))
+		return errors.E(op, err)
 	}
 
 	d.log.Debug("ping kafka: ok", zap.String("driver", pipe.Driver()), zap.String("pipeline", pipe.Name()))


### PR DESCRIPTION
# Reason for This PR

This change provide full error when kafka ping was failed

## Description of Changes

In previous version ping no returns full error. This PR fixed the behavior.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
