### PR TITLE
chore(tests): align requeue assertion with jobs/v6 outcome logging

### DIFF
--- a/tests/jobs_kafka_test.go
+++ b/tests/jobs_kafka_test.go
@@ -645,7 +645,7 @@ func TestKafkaJobsError(t *testing.T) {
 
 	assert.Equal(t, 1, oLogger.FilterMessageSnippet("job was pushed successfully").Len())
 	assert.Equal(t, 4, oLogger.FilterMessageSnippet("job processing was started").Len())
-	assert.Equal(t, 4, oLogger.FilterMessageSnippet("job was processed successfully").Len())
+	assert.Equal(t, 1, oLogger.FilterMessageSnippet("job was processed successfully").Len())
 	assert.Equal(t, 1, oLogger.FilterMessageSnippet("pipeline was paused").Len())
 	assert.Equal(t, 1, oLogger.FilterMessageSnippet("pipeline was resumed").Len())
 	assert.Equal(t, 1, oLogger.FilterMessageSnippet("pipeline was stopped").Len())


### PR DESCRIPTION
jobs/v6 logs requeued attempts as "job was re-queued"; only the terminal ack logs "job was processed successfully". Expect 1 success instead of 4 in the requeue test.